### PR TITLE
[fix] update blog in branch `master` will loss commits

### DIFF
--- a/.github/workflows/generate_readme.yml
+++ b/.github/workflows/generate_readme.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           path: main
 
       - name: Checkout Blog


### PR DESCRIPTION
Action `Checkout` just fetch one commit log as default, when `git push --force`, other commit log will be covered.

Use `fetch-depth: 0` to make sure action `Checkout` fetch all commits.